### PR TITLE
add symfony/yaml dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
   "type": "composer-plugin",
   "require": {
     "composer-plugin-api": "^1.0.0",
+    "symfony/yaml": "^3.4",
     "webflo/drupal-finder": "^1.1",
     "webmozart/path-util": "^2.3"
   },
@@ -17,7 +18,8 @@
   "autoload": {
     "psr-4": {
       "Grasmash\\ComposerConverter\\": "src",
-      "Grasmash\\ComposerConverter\\Composer\\": "src/Composer"
+      "Grasmash\\ComposerConverter\\Composer\\": "src/Composer",
+      "Symfony\\Component\\Yaml\\Yaml": "vendor/symfony/yaml"
     }
   },
   "autoload-dev": {


### PR DESCRIPTION
First ever pull request, also not too sure this is the _best_ way to implement this change either. Feel free to rip me a new one!

Tested on my own server, satisfies issue #3 which threw an error concerning Symfony\Component\Yaml\Yaml class not being found in the DrupalInspector class.