### PR TITLE
Update Usage with relative paths; added cPanel example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,13 @@ The `[drupal-root]` should be the Drupal root, where `index.php` is located.
 Examples:
 ```
 # Drupal is located in a `docroot` subdirectory.
-composer composerize-drupal --composer-root=. --drupal-root=docroot
+composer composerize-drupal --composer-root=. --drupal-root=./docroot
 
 # Drupal is located in a `web` subdirectory.
-composer composerize-drupal --composer-root=. --drupal-root=web
+composer composerize-drupal --composer-root=. --drupal-root=./web
+
+# Drupal is located in a `public_html` subdirectory (cPanel compatible).
+composer composerize-drupal --composer-root=. --drupal-root=./public_html
 
 # Drupal is located in the repository root, not in a subdirectory.
 composer composerize-drupal --composer-root=. --drupal-root=.


### PR DESCRIPTION
Your _composerize-drupal_ has worked really well. The only thing I found is if I just used the directory name for `--drupal-root` then my _composer.json_ prefixed all my Drupal directory paths with `../`.

Example...
```
"installer-paths": {
            "drush/Commands/{$name}": [
                "type:drupal-drush"
            ],
            "../public_html/core": [
                "type:drupal-core"
            ],
            "../public_html/modules/contrib/{$name}": [
                "type:drupal-module"
            ],
            ...
```

When I used a relative path (ie. added `./` to my `--drupal-root`), the _composer.json_ file was created with the correct paths to my Drupal directory.

So thought I'd suggest updating your usage instructions with this info.

I also added another example for those of us (stuck) using cPanel.

Hope this helps. :)