### PR TITLE
Composer.json permit higher symfony/yaml version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "composer-plugin-api": "^2.0",
     "composer/semver": "^3",
     "symfony/finder": "^3.4",
-    "symfony/yaml": "^3.4",
+    "symfony/yaml": "^3.4|^5.0",
     "webflo/drupal-finder": "^1.1",
     "webmozart/path-util": "^2.3"
   },


### PR DESCRIPTION
Changing to allow 5.x symfony/yaml which might be OK. Have not tested this. https://github.com/grasmash/composerize-drupal/issues/39

Noted here as people have higher yaml requirements sometimes.
https://github.com/grasmash/composerize-drupal/issues/39