### PR TITLE
Acquia packages are not supported in composerize process

### DIFF
--- a/src/Composer/ComposerizeDrupalCommand.php
+++ b/src/Composer/ComposerizeDrupalCommand.php
@@ -173,6 +173,9 @@ class ComposerizeDrupalCommand extends BaseCommand
     protected function requireContribProjects($root_composer_json, $projects)
     {
         foreach ($projects as $project_name => $project) {
+            // @todo
+            // Failed composerize process for Acquia packages ex.- acquia/acquia_cms, acquia/cohesion etc.
+            // Need to discuss.
             $package_name = "drupal/$project_name";
             $version_constraint = DrupalInspector::getVersionConstraint($project['version'], $this->input->getOption('exact-versions'));
             $root_composer_json->require->{$package_name} = $version_constraint;


### PR DESCRIPTION
As per analysis & investigation, we identified in Drupal composerize process is not supported for acquia packages.
 
<img width="972" alt="Screenshot 2022-05-31 at 6 34 20 PM" src="https://user-images.githubusercontent.com/75003339/171179936-019d1e49-8f8d-4584-bcca-6c993c950c0f.png">

For this reason some of the docroot not able to composerize by ra-up process.

Action- Need to discuss the possible solution.

Proposed solution- 

- we need to filter acquia packages  and in places of 'drupal/$package_name' need to use 'acquia/$package_name'.
 